### PR TITLE
Feature/rotate intermine vms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-# ignore
+# ignore Vim
 *.swp
 *.swo
 *~
+
+*hardcopy.*
+*screenlog.*
+
+intermine/local/*

--- a/intermine/README.md
+++ b/intermine/README.md
@@ -1,0 +1,29 @@
+#intermine release tool
+
+This tool allows you to migrate a dev intermine box to prodcution on AWS. 
+
+
+##Installation
+
+###Install CPAN
+
+```bash
+yum install perl-CPAN
+```
+
+or
+
+```bash
+apt-get install cpan
+```
+###Install Carton
+
+```bash
+sudo cpan Carton
+```
+
+
+#Install requirements with Carton
+```bash
+carton install
+```

--- a/intermine/README.md
+++ b/intermine/README.md
@@ -5,6 +5,7 @@ This tool allows you to migrate a dev intermine box to prodcution on AWS.
 
 ##Installation
 
+
 ###Install CPAN
 
 ```bash
@@ -18,12 +19,34 @@ apt-get install cpan
 ```
 ###Install Carton
 
+This is a work in progress. The cpanfile that Carton uses to install the modules locally works. At this point, I have not been able to figure out how to point the script at the locally installed modules. Instead of using Carton the modules listed in the cpanfile need to be installed seperately. 
+
 ```bash
 sudo cpan Carton
 ```
-
 
 #Install requirements with Carton
 ```bash
 carton install
 ```
+
+##Usage
+
+Currently the command is very simple: e.g. perl bin/rotate-intermine.pl 254
+
+The rollout_version is the version of the machine that you would like to roll into production.
+
+```bash
+perl bin/rotate-intermine.pl <rollout_version>
+```
+
+##Steps performeed
+
+1. AMI Created of rollout machine if does not already exist
+2. Tagging the image
+3. Creation of new development machine with the name of the next incremental database version
+4. Tagging the new machine
+5. Adding a CNAME for the new machine
+6. Changing the tag for the rollout machine to production
+7. Changing security group for rollout machine to production group
+8. Changing CNAME for intermine.wormbase.org to point to new production intermine machine

--- a/intermine/bin/rotate-intermine.pl
+++ b/intermine/bin/rotate-intermine.pl
@@ -89,6 +89,9 @@ else {
    say "\t\tcreate CNAME";
    my $command = "aws route53 change-resource-record-sets --hosted-zone-id";
 
+   say "\tCOMMAND: $command";
+   ($stdout, $stderr) = capture {system($command)};
+   die "error $stderr" if $stderr;
 }
 
 say "Adding CNAME record for $new_name";

--- a/intermine/bin/rotate-intermine.pl
+++ b/intermine/bin/rotate-intermine.pl
@@ -1,0 +1,117 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use autodie qw(:all);
+use feature qw(say);
+
+use JSON::XS;
+use Capture::Tiny ':all';
+
+use Data::Dumper;
+
+my $im_security_group = "intermine-dev";
+my $subnet_id = "subnet-a33a2bd5";
+
+my $username = "awright";
+my $rollout_version = 253;
+my $new_version = $rollout_version + 1;
+$new_version .= "-test";
+
+my $old_name = "im-$rollout_version.wormbase.org";
+my $new_im_name = "im-$new_version.wormbase.org";
+
+
+my $coder = JSON::XS->new->ascii->pretty->allow_nonref;
+
+my ($stdout, $stderr);
+
+say "Pulling image information";
+my $command = "aws ec2 describe-images"; 
+say "\t$command";
+($stdout, $stderr) = capture {system($command)};
+die "error $stderr" if $stderr;
+
+my $images = $coder->decode($stdout);
+
+my $im_image;
+foreach my $image (@{$images->{Images}}) {
+    if (defined($image->{Name}) && ($image->{Name} =~ /im-$rollout_version\.wormbase\.org/)) {
+       $im_image = $image;
+       last;
+    }
+}
+
+say "Pulling Instance Information";
+$command = "aws ec2 describe-instances";
+say "\t$command";
+($stdout, $stderr) = capture { system($command) };
+die "error $stderr" if $stderr;
+
+my $response = $coder->decode($stdout);
+
+my %im_instances;
+foreach my $reservation (@{$response->{Reservations}}) {
+    my $instances = $reservation->{Instances};
+    my ($key, $value);
+    foreach my $instance (@{$reservation->{Instances}}) {
+        my %tags;
+        foreach my $tag (@{$instance->{Tags}}) {
+            $key = $tag->{Key};
+            $value = $tag->{Value};
+            $tags{$key} = $value;
+        }
+        if ($tags{Name} =~ /im.*\.wormbase\.org/) {
+            $instance->{Tags} = \%tags;
+            $im_instances{$tags{Name}} = $instance;
+        }
+    }
+}
+
+say "Creating image of $old_name";
+if (not defined $im_image) {
+#   aws --region=us-east-1 ec2 create-image --instance-id "PROD" --name "wormine backup" --description "This image gets created from the development instance of wormine when it is ready to be roled out into production"
+}
+else {
+    say "SKIPPING: image of $old_name already exists";
+}
+
+
+say "Creating $new_im_name";
+if (defined $im_instances{$new_im_name}) { 
+    say "SKIPPING: $new_im_name already exists";
+}
+else {
+   my $ami = $im_instances{$old_name};
+   my $image_id = $ami->{ImageId};
+   my $ami_instance_type = $ami->{InstanceType};
+   my $instance_type = ($ami_instance_type eq "m4.2xlarge")? "m3.2xlarge" : "m4.2xlarge"; 
+   my $key_name = $ami->{KeyName};
+   $command = "aws --region=us-east-1 ec2 run-instances --image-id $image_id --count 1 --instance-type $instance_type --key-name $key_name --subnet-id=$subnet_id";
+   say "\t$command";     
+  
+   ($stderr, $stdout) = capture {system($command)};
+   die "error $stderr" if $stderr;
+   
+   print Dumper $stdout;
+   $response = $coder->decode($stdout);
+   my @instances = @{$response->{Instances}};
+   my $instance = $instances[0];
+   my $new_instance_id = $instance->{InstanceId};
+   say "new instance id: $new_instance_id";
+
+   $command = "aws ec2 create-tag --resources --tags \"Name=$new_im_name,Client=OICR,CreatedBy=$username,Project=WormBase,Release=WS$new_version,Role=intermine,Status=development\"";
+   say "tagging manchine";
+   say "\t$command";
+   ($stderr, $stdout) = capture {system($command)};
+
+   say "result of command";
+   print Dumper $stdout;
+}
+
+
+say "DONE";
+#delete-instance: @aws --region=us-east-1 ec2 \
+#                        terminate-instances  \
+#                        --instance-ids PROD

--- a/intermine/bin/rotate-intermine.pl
+++ b/intermine/bin/rotate-intermine.pl
@@ -12,26 +12,19 @@ use Capture::Tiny ':all';
 
 use Data::Dumper;
 
-###USAGE perl bin/rotate-intermine.pl <rollout_version>
-#
-# 1)change variable values at top of this script
-# 2)run command (ex. perl bin/rotate-intermine.pl 254)
-#
-# This command would make a ami of im254 and then make an instance im255. Followed by changing the status tag for im254 to production. At this point it will also change the CNAME for ws254 so that intermine.wormbase.org points to it.  
-
 my $im_security_group = "intermine-dev";
 my $subnet_id = "subnet-a33a2bd5";
 
-my $intermine_url = "intermine-test.wormbase.org";
-#my $intermine_url = "intermine.wormbase.org";
+##If you want to test this script change which line is commented for defining the $intermine_url and uncomment the changing of the $rollout_version and the $new_version
+
+#my $intermine_url = "intermine-test.wormbase.org";
+my $intermine_url = "intermine.wormbase.org";
 
 my $username = "awright";
 my $rollout_version = $ARGV[0];
 my $new_version = $rollout_version + 1;
-$rollout_version .= "-test";
-$new_version .= "-test";
-
-
+#$rollout_version .= "-test";
+#$new_version .= "-test";
 
 my $old_name = "im-$rollout_version.wormbase.org";
 my $new_name = "im-$new_version.wormbase.org";
@@ -317,5 +310,3 @@ sub get_im_image {
 
     return $im_image;
  }   
-
-

--- a/intermine/bin/rotate-intermine.pl
+++ b/intermine/bin/rotate-intermine.pl
@@ -6,17 +6,26 @@ use warnings;
 use autodie qw(:all);
 use feature qw(say);
 
+use DateTime;
 use JSON::XS;
 use Capture::Tiny ':all';
 
 use Data::Dumper;
 
+###USAGE perl bin/rotate-intermine.pl <rollout_version>
+#
+# 1)change variable values at top of this script
+# 2)run command (ex. perl bin/rotate-intermine.pl 254)
+#
+# This command would make a ami of im254 and then make an instance im255. Followed by changing the status tag for im254 to production. At this point it will also change the CNAME for ws254 so that intermine.wormbase.org points to it.  
+
 my $im_security_group = "intermine-dev";
 my $subnet_id = "subnet-a33a2bd5";
 
 my $username = "awright";
-my $rollout_version = 253;
+my $rollout_version = $ARGV[0];
 my $new_version = $rollout_version + 1;
+$rollout_version .= "-test";
 $new_version .= "-test";
 
 my $old_name = "im-$rollout_version.wormbase.org";
@@ -27,91 +36,269 @@ my $coder = JSON::XS->new->ascii->pretty->allow_nonref;
 
 my ($stdout, $stderr);
 
-say "Pulling image information";
-my $command = "aws ec2 describe-images"; 
-say "\t$command";
-($stdout, $stderr) = capture {system($command)};
-die "error $stderr" if $stderr;
+say "Getting Image Information";
+my $im_image = get_im_image($rollout_version);
 
-my $images = $coder->decode($stdout);
+say "Getting Instance Information";
+my $im_instances = get_im_instances();
 
-my $im_image;
-foreach my $image (@{$images->{Images}}) {
-    if (defined($image->{Name}) && ($image->{Name} =~ /im-$rollout_version\.wormbase\.org/)) {
-       $im_image = $image;
-       last;
-    }
-}
+say "Getting Security Group IDs";
+my $security_group_ids = get_security_groups();
 
-say "Pulling Instance Information";
-$command = "aws ec2 describe-instances";
-say "\t$command";
-($stdout, $stderr) = capture { system($command) };
-die "error $stderr" if $stderr;
+say "Getting Host Zone ID";
+my $hosted_zone_id = get_hosted_zone_id();
 
-my $response = $coder->decode($stdout);
+say "Getting CNAME Records";
+my $cname_records = get_cname_records($hosted_zone_id);
 
-my %im_instances;
-foreach my $reservation (@{$response->{Reservations}}) {
-    my $instances = $reservation->{Instances};
-    my ($key, $value);
-    foreach my $instance (@{$reservation->{Instances}}) {
-        my %tags;
-        foreach my $tag (@{$instance->{Tags}}) {
-            $key = $tag->{Key};
-            $value = $tag->{Value};
-            $tags{$key} = $value;
-        }
-        if ($tags{Name} =~ /im.*\.wormbase\.org/) {
-            $instance->{Tags} = \%tags;
-            $im_instances{$tags{Name}} = $instance;
-        }
-    }
-}
+if (not defined $im_image)  {
+   say "Image of instance $old_name not found. About to create image";
+   die("Could not proceed: Both image and instance of $old_name were not found") if (not defined $im_instances->{$old_name});
 
-say "Creating image of $old_name";
-if (not defined $im_image) {
-#   aws --region=us-east-1 ec2 create-image --instance-id "PROD" --name "wormine backup" --description "This image gets created from the development instance of wormine when it is ready to be roled out into production"
+   say "Creating image of instance $old_name";
+   my $instance = $im_instances->{$old_name};
+   my $image_id = create_image($instance, $old_name);
+
+   tag_resource($old_name, $image_id, $username, $rollout_version, "production");
+   say "created $image_id";
+   $im_instances = get_im_instances();
 }
 else {
     say "SKIPPING: image of $old_name already exists";
 }
 
+my ($command, $response);
 
 say "Creating $new_im_name";
-if (defined $im_instances{$new_im_name}) { 
+if (defined $im_instances->{$new_im_name}) { 
     say "SKIPPING: $new_im_name already exists";
 }
 else {
-   my $ami = $im_instances{$old_name};
-   my $image_id = $ami->{ImageId};
-   my $ami_instance_type = $ami->{InstanceType};
-   my $instance_type = ($ami_instance_type eq "m4.2xlarge")? "m3.2xlarge" : "m4.2xlarge"; 
-   my $key_name = $ami->{KeyName};
-   $command = "aws --region=us-east-1 ec2 run-instances --image-id $image_id --count 1 --instance-type $instance_type --key-name $key_name --subnet-id=$subnet_id";
-   say "\t$command";     
-  
-   ($stderr, $stdout) = capture {system($command)};
-   die "error $stderr" if $stderr;
+   my $ami = $im_instances->{$old_name};
    
-   print Dumper $stdout;
-   $response = $coder->decode($stdout);
+   my $response = create_instance_from_ami($ami);
+
    my @instances = @{$response->{Instances}};
    my $instance = $instances[0];
    my $new_instance_id = $instance->{InstanceId};
    say "new instance id: $new_instance_id";
 
-   $command = "aws ec2 create-tag --resources --tags \"Name=$new_im_name,Client=OICR,CreatedBy=$username,Project=WormBase,Release=WS$new_version,Role=intermine,Status=development\"";
    say "tagging manchine";
-   say "\t$command";
-   ($stderr, $stdout) = capture {system($command)};
 
-   say "result of command";
-   print Dumper $stdout;
+   tag_resource($new_im_name, $new_instance_id, $username, $new_version, "development");
+
+   say "create CNAME";
+   my $command = "aws route53 change-resource-record-sets --hosted-zone-id";
+
 }
 
+say "Adding CNAME record for $new_im_name";
+if (defined $cname_records->{$new_im_name}) {
+    say "SKIPPING: CNAME record already exists";
+}
+else {
+    say "creating cname record";
+    my $command = aws route53 change-resource-record-sets --hosted-zone-id --change-batch '{ "Comment": "Created by rotate-intermine.pl","Changes":[{"Action": "CREATE","ResourceRecordSet": {"Name": "api.realguess.net.","Type": "CNAME","TTL": 300,"ResourceRecords": [{"Value": "'.www.realguess.net.'"}]}}]}'
+}
 
+say "Changing tag for $old_name to production and changing security group to production";
+if (defined $im_instances->{$old_name}) {
+    my $instance = $im_instances->{$old_name};
+    my $dev_instance_id = $instance->{InstanceId};
+    my $command = "aws ec2 create-tags --resources $dev_instance_id --tags \"Key=Status,Value=production\"";
+    say "\tCOMMAND: $command";
+    ($stdout, $stderr) = capture {system($command)};
+    die "error $stderr" if $stderr;
+
+    my $prod_security_group_id = $security_group_ids->{prod};
+
+    $command = "aws ec2 modify-instance-attribute --instance-id $dev_instance_id --groups $prod_security_group_id";
+    say "\tCOMMAND: $command";
+
+    ($stdout, $stderr) = capture {system($command)};
+    die "error $stderr" if $stderr;
+}
+else {
+    say "SKIPPING: $old_name instance not found";
+}
+ 
 say "DONE";
-#delete-instance: @aws --region=us-east-1 ec2 \
-#                        terminate-instances  \
-#                        --instance-ids PROD
+
+sub create_instance_from_ami {
+   my ($ami) = @_;
+
+   my $image_id = $ami->{ImageId};
+   my $ami_instance_type = $ami->{InstanceType};
+   my $instance_type = ($ami_instance_type eq "m4.2xlarge")? "m3.2xlarge" : "m4.2xlarge"; 
+   my $key_name = $ami->{KeyName};
+
+   $command = "aws --region=us-east-1 ec2 run-instances --security-group \"intermine-dev\" --image-id $image_id --count 1 --instance-type $instance_type --key-name $key_name --subnet-id=$subnet_id";
+   say "\tCOMMAND: $command";     
+
+   ($stdout, $stderr) = capture {system($command)};
+   die "error $stderr" if $stderr;
+   
+   $response = $coder->decode($stdout);
+
+   return $response;
+}
+
+sub tag_resource {
+   my ($name, $resource, $username, $version, $status) = @_;
+
+   my $dt = DateTime->now;
+   my $date = $dt->ymd('.');
+
+   my %tags = ("Name" => $name,
+               "Client" => "OICR",
+               "CreatedBy" => $username,
+               "Date" => $date,
+               "Project" => "WormBase",
+               "Release" => "WS$version",
+               "Role" => "intermine",
+               "Status" => $status);
+
+   my $value;        
+   foreach my $key (keys %tags) {
+       $value = $tags{$key};
+       $command = "aws ec2 create-tags --resources $resource --tags \"Key=$key,Value=$value\"";
+       say "\tCOMMAND: $command";
+       ($stdout, $stderr) = capture {system($command)};
+       die "error $stderr" if $stderr;
+   }
+
+}
+
+sub get_security_groups {
+    $command = "aws ec2 describe-security-groups";
+    say "\tCOMMAND: $command";
+    ($stdout, $stderr) = capture {system($command)};
+    die "error $stderr" if $stderr;
+       
+    $response = $coder->decode($stdout);
+
+    my @security_groups = @{$response->{SecurityGroups}};
+
+    my %im_security_group_ids;
+    foreach my $security_group (@security_groups) {
+        if ($security_group->{GroupName}  eq "intermine-production") {
+             $im_security_group_ids{prod} = $security_group->{"GroupId"};
+        }
+        elsif ($security_group->{GroupName}  eq "intermine-dev") {
+             $im_security_group_ids{dev} = $security_group->{"GroupId"};
+        }
+    }
+
+    return \%im_security_group_ids;
+}
+
+sub create_image {
+   my ($instance, $name) = @_;
+
+   my $instance_id = $instance->{InstanceId};
+   $command = "aws --region=us-east-1 ec2 create-image --instance-id $instance_id --name \"$name\" --description \"Created from the development instance of wormine when it is ready to be rolled out into production\"";
+   say $command;
+
+   ($stdout, $stderr) = capture {system($command)};
+   die "error $stderr" if $stderr;
+
+   $response = $coder->decode($stdout);
+   my $image_id = $response->{ImageId};
+   
+   return $image_id;
+}
+
+sub get_im_instances {
+
+    $command = "aws ec2 describe-instances";
+    say "\tCOMMAND: $command";
+    ($stdout, $stderr) = capture { system($command) };
+    die "error $stderr" if $stderr;
+    
+    my $response = $coder->decode($stdout);
+    
+    my %im_instances;
+    foreach my $reservation (@{$response->{Reservations}}) {
+        my $instances = $reservation->{Instances};
+        my ($key, $value);
+        foreach my $instance (@{$reservation->{Instances}}) {
+            my %tags;
+            foreach my $tag (@{$instance->{Tags}}) {
+                $key = $tag->{Key};
+                $value = $tag->{Value};
+                $tags{$key} = $value;
+            }
+            if ((defined $tags{Name}) && ($tags{Name} =~ /im.*\.wormbase\.org/)) {
+                $instance->{Tags} = \%tags;
+                $im_instances{$tags{Name}} = $instance;
+            }
+        }
+    }
+
+    return \%im_instances;
+}
+
+sub get_hosted_zone_id {
+    my $command = "aws route53 list-hosted-zones";
+
+    say "\tCOMMAND: $command";
+    ($stdout, $stderr) = capture { system($command) };
+    die "error $stderr" if $stderr;
+    
+    my $response = $coder->decode($stdout);
+    my @hosted_zones = @{$response->{HostedZones}};
+
+    foreach my $zone (@hosted_zones) {
+        if ($zone->{Name} eq "wormbase.org.") {
+            my $id = $zone->{Id};
+            $id =~ /\/hostedzone\/(.*)/;
+            return $1;
+        }
+    }
+}
+
+sub get_cname_records {
+    my ($hosted_zone_id) = @_;
+
+    my $command = "aws route53 list-resource-record-sets --hosted-zone-id $hosted_zone_id";
+
+    say "\tCOMMAND: $command";
+    ($stdout, $stderr) = capture { system($command) };
+    die "error $stderr" if $stderr;
+    
+    my $response = $coder->decode($stdout);
+    
+    my @resource_record_set = @{$response->{ResourceRecordSets}};
+
+    my %cname_records;
+    foreach my $record (@resource_record_set) {
+        if ($record->{Type} eq "CNAME") { 
+           $cname_records{$record->{Name}} = $record; 
+        }
+    }
+
+    return \%cname_records;   
+}
+
+sub get_im_image {
+    my ($rollout_version) = @_;
+
+    my $command = "aws ec2 describe-images"; 
+    say "\tCOMMAND: $command";
+    ($stdout, $stderr) = capture {system($command)};
+    die "error $stderr" if $stderr;
+    
+    my $images = $coder->decode($stdout);
+    
+    my $im_image;
+    foreach my $image (@{$images->{Images}}) {
+        if (defined($image->{Name}) && ($image->{Name} =~ /im-$rollout_version\.wormbase\.org/)) {
+           $im_image = $image;
+           last;
+        }
+    }
+
+    return $im_image;
+ }   
+
+

--- a/intermine/cpanfile
+++ b/intermine/cpanfile
@@ -1,0 +1,3 @@
+requires "JSON::XS";
+requires "Capture::Tiny";
+requires "IO::CaptureOutput";

--- a/intermine/cpanfile
+++ b/intermine/cpanfile
@@ -1,3 +1,4 @@
 requires "JSON::XS";
 requires "Capture::Tiny";
 requires "IO::CaptureOutput";
+requires "Date::Time";

--- a/intermine/cpanfile.snapshot
+++ b/intermine/cpanfile.snapshot
@@ -1,0 +1,63 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  Canary-Stability-2012
+    pathname: M/ML/MLEHMANN/Canary-Stability-2012.tar.gz
+    provides:
+      Canary::Stability 2012
+    requirements:
+      ExtUtils::MakeMaker 0
+  Capture-Tiny-0.44
+    pathname: D/DA/DAGOLDEN/Capture-Tiny-0.44.tar.gz
+    provides:
+      Capture::Tiny 0.44
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      File::Spec 0
+      File::Temp 0
+      IO::Handle 0
+      Scalar::Util 0
+      perl 5.006
+      strict 0
+      warnings 0
+  IO-CaptureOutput-1.1104
+    pathname: D/DA/DAGOLDEN/IO-CaptureOutput-1.1104.tar.gz
+    provides:
+      IO::CaptureOutput 1.1104
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      File::Basename 0
+      File::Temp 0.16
+      Symbol 0
+      perl 5.006
+      strict 0
+      vars 0
+      warnings 0
+  JSON-XS-3.02
+    pathname: M/ML/MLEHMANN/JSON-XS-3.02.tar.gz
+    provides:
+      JSON::XS 3.02
+    requirements:
+      Canary::Stability 0
+      ExtUtils::MakeMaker 6.52
+      Types::Serialiser 0
+      common::sense 0
+  Types-Serialiser-1.0
+    pathname: M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz
+    provides:
+      JSON::PP::Boolean 1.0
+      Types::Serialiser 1.0
+      Types::Serialiser::BooleanBase 1.0
+      Types::Serialiser::Error 1.0
+    requirements:
+      ExtUtils::MakeMaker 0
+      common::sense 0
+  common-sense-3.74
+    pathname: M/ML/MLEHMANN/common-sense-3.74.tar.gz
+    provides:
+      common::sense 3.74
+    requirements:
+      ExtUtils::MakeMaker 0

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -409,7 +409,7 @@
     "InstanceType": {
       "Description": "Type of EC2 instance to launch",
       "Type": "String",
-      "Default": "m3.large"
+      "Default": "c3.xlarge"
     },
     "UserName": {
       "Type": "String",

--- a/transactor/config/wb-cf.properties
+++ b/transactor/config/wb-cf.properties
@@ -5,7 +5,7 @@
 # required
 # AWS instance type. See http://aws.amazon.com/ec2/instance-types/ for
 # a list of leegal instance types.
-aws-instance-type=m3.large
+aws-instance-type=c3.xlarge
 
 # required, see http://docs.amazonwebservices.com/general/latest/gr/rande.html#ddb_region
 aws-region=us-east-1


### PR DESCRIPTION
I have created a Perl script that wraps around the AWS interfaces in order to automate the process of rotating from one Intermine machine version to another. 

@paulo I added you to this as an assignee as I think you should be aware of the process that is being used for the roll out process. 

There is a README file in the Intermine folder that explains how to run the tool. 

I am not sure exactly what AWS services need to be installed to run the tool but for sure the main AWS services I am working with are ec2 and route53. If on your machine you do not have these tools they will need to be installed. 

The user will also have to make sure that AWS has access to the users credentials. 

Testing

I have created machines that run, theoretically, the same way that the production machines work. The only difference is that I added "-test" into the names of the machines. If you are wanting to test 3 lines need to be adjusted in the script to add the "-test" into the machine name and an initial "-test" machine needs to be created. 

Everything looked good and, although I am sure there will be a couple, I am not aware of other functionality that the script should do but doesn't. 

Future work:

- These scripts will  need to be run and adjusted in production. Preferably during a release cycle. 
- I have not tested to see if the machines are provisioned correctly, once they are generated by the script. If they are not provisioning code should be added. 
- Ideally we would start automating the first steps on the next machine. For example pulling in the latest XML aceDB dump files to the machine. Possibly clearing old data from the file system to make room for new content.  