### PR TITLE
Improve documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,123 @@
-[![Build Status](https://travis-ci.org/WormBase/wormbase-architecture.svg?branch=develop)](https://travis-ci.org/WormBase/wormbase-architecture) 
+[![Build Status](https://travis-ci.org/WormBase/wormbase-architecture.svg?branch=develop)](https://travis-ci.org/WormBase/wormbase-architecture)
 
 # wormbase-architecture
-This repository is a set of code that can be used to setup the various WormBase environments
+This repository is a set of code that can be used to setup the various
+WormBase environments.
 
 The main provisioning tool that is used in the repostitory is Ansible.
 
-##Getting started - install Ansible
+## Getting started - install Ansible
 
-First you will need to install docker and other dependencies on your host machine.
+First you will need to install docker and other dependencies on your
+host machine.
 
 ### mount devices
-        Follow instruction from http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-using-volumes.html
-        eg. sudo mkfs -t xfs /dev/xvdf; sudo mount /dev/xvdf /datastore;
+    Follow instructions for [mounting volumes][1].
+    eg. `sudo mkfs -t xfs /dev/xvdf; sudo mount /dev/xvdf /datastore;`
 
 ### start datomic transactor
-	sudo ~/datomic/bin/transactor ~/datomic_configs/free-transactor.properties
 
-###Command 1
-	ansible-playbook -i inventory install.yml
+```bash
+sudo ~/datomic/bin/transactor \
+     ~/datomic_configs/free-transactor.properties
+```
 
-###Command 2
-	ansible-playbook -i inventory site.yml
+### Command 1
 
-###Result 
-	When you run "sudo docker images" you should now see the image "wormbase-datomic" listed as a docker image
+```bash
+ansible-playbook -i inventory install.yml
+```
+
+### Command 2
+```bash
+ansible-playbook -i inventory site.yml
+```
+
+### Result
+When you run `docker images` you should now see the image
+"wormbase-datomic" listed as a docker image.
 
 
-##Loading data into acedb
-        foreach acefile (`ls /datastore/acedb/raw-data/WS250/*.ace`)
-            tace <<quit
-                parse $acefile
-            quit
-        end
+## Loading data into acedb
+
+foreach acefile (`ls /datastore/acedb/raw-data/WS250/*.ace`)
+    tace <<quit
+        parse $acefile
+    quit
+end
 
 
 ## Using Containers
 
-###General
+### General
 
-####To figure see the running docker container
+#### Identify running docker containers
 
-	sudo docker ps
+```bash
+docker ps -a
+```
 
-####To figure out the docker containers ip address
+#### To figure out the docker containers ip address
 
-	sudo  docker inspect  (look for NetworkSettings -> IPAddress )
+```bash
+docker inspect  (look for NetworkSettings -> IPAddress )
+```
 
-####To connect to machine and inspect the container with bash 
+#### To connect to machine and inspect the container with bash
 
-	sudo docker exec -it <container-id | container-name> bash
+```bash
+docker exec -it <container-id | container-name> bash
+```
 
-	
+### Database (postgresql)
 
-###Database (posgresql)
-
-This database could be used in stead of the free storage protocol with Datomic
+This database could be used in stead of the free storage protocol with
+Datomic.
 
 Data is stored in /var/log/postresql/data.
 
-####Log in from remote host
+#### Log in from remote host
 
-     psql -U postgres -h <postgres-container-ip-addr>  
+```bash
+psql -U postgres -h <postgres-container-ip-addr>
+```
 
-####Start Container
+#### Start Container
 
-     ansible-playbook -i inventory postgresql.yml;
+```bash
+ansible-playbook -i inventory postgresql.yml;
+```
 
-###Datomic
+### Datomic
 
-Datomic will already be running you will be able to connect with it either through port 4334 or through ssh
+Datomic will already be running you will be able to connect with it
+either through port 4334 or through ssh
 
-####To shell into the container
+#### To shell into the container
 
-	sudo docker exec -it wombase-datatomic /bin/bash
+```bash
+docker exec -it wombase-datatomic /bin/bash
+```
 
-###Datomic API
+### Datomic API
 
-        sudo docker run -d -P --name wormbase-datomic-api --link wormbase-datomic:wormbase-datomic wormbase-datomic-api /bin/bash
-
+```bash
+docker run -d -P \
+   --name wormbase-datomic-api \
+   --link wormbase-datomic:wormbase-datomic \
+          wormbase-datomic-api \
+   /bin/bash
+```
 
 ##Running lein
 
-I am following the docker links to make a connection to the datomic database. To do the host needs to be modified to 
+I am following the docker links to make a connection to the datomic database. To do the host needs to be modified to
 
 	(def uri "datomic:free://WORMBASE_DATOMIC_PORT_4224_TCP/wb250-imp1
 
 In the script on the following page:
 
 	https://github.com/WormBase/db/wiki/Timestamp-Importer
+
+[1]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-using-volumes.html
+


### PR DESCRIPTION
 - Add leading space to all headings
 - Removed sudo prefix from all docker commands (should not be
   required - if it is for some reason then I think we're doing docker
   wrong!)
 - Line length.
 - Format command-blocks using markdown code-blocks.