### PR TITLE
Feature/handle datomic upgrade

### DIFF
--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -384,6 +384,7 @@
       "ap-southeast-2": {"64p":"ami-32cbdf51", "64h":"ami-66647005"},
       "ap-south-1": {"64p":"ami-82126eed", "64h":"ami-723c401d"},
       "sa-east-1": {"64p":"ami-afd7b9c3", "64h":"ami-ab9af4c7"}
+    }
   },
   "Parameters": {
     "InstanceType": {

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -370,43 +370,20 @@
       }
     },
     "AWSRegionArch2AMI": {
-      "ap-northeast-1": {
-        "64p": "ami-952c6a94",
-        "64h": "ami-bf2f69be"
-      },
-      "us-west-1": {
-        "64p": "ami-3a9fa47f",
-        "64h": "ami-789fa43d"
-      },
-      "ap-southeast-1": {
-        "64p": "ami-ecfaa8be",
-        "64h": "ami-92faa8c0"
-      },
-      "us-west-2": {
-        "64p": "ami-1b13652b",
-        "64h": "ami-f51264c5"
-      },
-      "eu-central-1": {
-        "64p": "ami-e0a4a9fd",
-        "64h": "ami-e2a4a9ff"
-      },
-      "us-east-1": {
-        "64p": "ami-34ae4c5c",
-        "64h": "ami-82a94bea"
-      },
-      "eu-west-1": {
-        "64p": "ami-6d67a11a",
-        "64h": "ami-a566a0d2"
-      },
-      "ap-southeast-2": {
-        "64p": "ami-2d41da17",
-        "64h": "ami-c942d9f3"
-      },
-      "sa-east-1": {
-        "64p": "ami-df238ec2",
-        "64h": "ami-ad238eb0"
-      }
-    }
+      "ap-northeast-1": {"64p":"ami-eb494d8c", "64h":"ami-81f7cde6"},
+      "ap-northeast-2": {"64p":"ami-6eb66a00", "64h":"ami-f594489b"},
+      "ca-central-1": {"64p":"ami-204bf744", "64h":"ami-5e5be73a"},
+      "us-east-2": {"64p":"ami-5b42643e", "64h":"ami-896c4aec"},
+      "eu-west-2": {"64p":"ami-e52d3a81", "64h":"ami-55091e31"},
+      "us-west-1": {"64p":"ami-97cbebf7", "64h":"ami-442a0a24"},
+      "ap-southeast-1": {"64p":"ami-db1492b8", "64h":"ami-3e90165d"},
+      "us-west-2": {"64p":"ami-daa5c6ba", "64h":"ami-cb5030ab"},
+      "eu-central-1": {"64p":"ami-f3f02b9c", "64h":"ami-d564bcba"},
+      "us-east-1": {"64p":"ami-7f5f1e69", "64h":"ami-da5110cc"},
+      "eu-west-1": {"64p":"ami-66001700", "64h":"ami-77465211"},
+      "ap-southeast-2": {"64p":"ami-32cbdf51", "64h":"ami-66647005"},
+      "ap-south-1": {"64p":"ami-82126eed", "64h":"ami-723c401d"},
+      "sa-east-1": {"64p":"ami-afd7b9c3", "64h":"ami-ab9af4c7"}
   },
   "Parameters": {
     "InstanceType": {

--- a/transactor/config/wb-cf.properties
+++ b/transactor/config/wb-cf.properties
@@ -5,7 +5,7 @@
 # required
 # AWS instance type. See http://aws.amazon.com/ec2/instance-types/ for
 # a list of leegal instance types.
-aws-instance-type=m3.large
+aws-instance-type=c3.large
 
 # required, see http://docs.amazonwebservices.com/general/latest/gr/rande.html#ddb_region
 aws-region=us-east-1


### PR DESCRIPTION
@a8wright I've removed the use of our debug script (slack me for why)

~This is un-tested, but I believe it will enable our setup to work with `0.9.5561.543` and latest (until they change the AMIs they use again)~
I've tested this with the latest version of datomic (`0.9.5561.56`) and it works.
Similar changes would be required for any future AMI changes cognitect make to their default AMI (that this setup uses)
