### PR TITLE
allow acedb container to be killed via ctrl-c

### DIFF
--- a/roles/acedb/files/Dockerfile
+++ b/roles/acedb/files/Dockerfile
@@ -58,9 +58,9 @@ RUN useradd -g acedb acedb
 RUN mkdir -p /root/acedb;
 WORKDIR /root/acedb
 
-COPY acedb-4.9.52.tgz .
-CMD chmod 777 acedb-4.9.52.tgz
-RUN tar xzf acedb-4.9.52.tgz
+ADD acedb-4.9.52.tgz .
+
+COPY entrypoint.sh .
 
 ENV ACEDB_MACHINE LINUX_4
 
@@ -68,5 +68,4 @@ ENV ACEDB_MACHINE LINUX_4
 WORKDIR /root/acedb
 
 #test ace
-ENTRYPOINT ["./acedb-4.9.52/sgifaceserver"]
-CMD ["./wormbase", "2005"]
+CMD ["./entrypoint.sh", "./acedb-4.9.52/sgifaceserver", "wormbase", "2005"]

--- a/roles/acedb/files/entrypoint.sh
+++ b/roles/acedb/files/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec yes | "$@"


### PR DESCRIPTION
Normally Ctrl-C triggers a prompt that blocks it from quitting immediately. 

In multi-container context (ie. `eb local run`), it's preventing the acedb to shut down, as I have no way to interact with the prompt directly.

The solution implemented here is to pipe the `yes` to sgifaceserver.