### PR TITLE
Feature/set datomic ext classpath for transactor

### DIFF
--- a/transactor/bin/manage
+++ b/transactor/bin/manage
@@ -218,6 +218,10 @@ def _parameter(name, value=None):
 @manage.command()
 @click.argument('ddb_table_name')
 @click.argument('datomic_version')
+@option('--datomic-transactor-deps-script',
+        default=None,
+        type=str,
+        help=('Optional custom script to install dependencies for a trasactor.'))
 @option('--datomic-ext-classpath-script',
         default=None,
         type=str,
@@ -230,6 +234,7 @@ def _parameter(name, value=None):
 def create(ctx,
            ddb_table_name,
            datomic_version,
+           datomic_transactor_deps_script,
            datomic_ext_classpath_script,
            desired_capacity,
            cf_template_path):
@@ -244,6 +249,8 @@ def create(ctx,
     ]
     if datomic_ext_classpath_script:
         params += [_parameter('DatomicExtClasspathScript', datomic_ext_classpath_script)]
+    if datomic_transactor_deps_script:
+        params += [_parameter('DatomicTransactorDepsScript', datomic_transactor_deps_script)]
     params.extend(_parameter(k, v)
                   for (k, v) in  ctx.params.items())
     kw = dict(StackName=ctx.cf_stack_name,
@@ -259,6 +266,10 @@ def create(ctx,
         default=None,
         type=str,
         help='If not specified, use existing version')
+@option('--datomic-transactor-deps-script',
+        default=None,
+        type=str,
+        help=('Optional custom script to install dependencies for a trasactor.'))
 @option('--datomic-ext-classpath-script',
         default=None,
         type=str,
@@ -271,6 +282,7 @@ def create(ctx,
 def update(ctx,
            ddb_table_name,
            datomic_version,
+           datomic_transactor_deps_script,
            datomic_ext_classpath_script,
            desired_capacity,
            cf_template_path):
@@ -282,6 +294,8 @@ def update(ctx,
         _parameter('DatomicVersion', datomic_version),
         _parameter('AutoScalingDesiredCapacity', desired_capacity),
     ]
+    if datomic_transactor_deps_script:
+        params += [_parameter('DatomicTransactorDepsScript', datomic_transactor_deps_script)]
     if datomic_ext_classpath_script:
         params += [_parameter('DatomicExtClasspathScript', datomic_ext_classpath_script)]
     params.extend(_parameter(k, v)

--- a/transactor/bin/manage
+++ b/transactor/bin/manage
@@ -218,6 +218,11 @@ def _parameter(name, value=None):
 @manage.command()
 @click.argument('ddb_table_name')
 @click.argument('datomic_version')
+@option('--datomic-ext-classpath-script',
+        default=None,
+        type=str,
+        help=('Optional arguments to custom script to download dependencies '
+              'and build the classpath string for DATOMIC_EXT_CLASSPATH, if provided.'))
 @desired_capacity_option()
 @template_path_option()
 @pass_command_context
@@ -225,6 +230,7 @@ def _parameter(name, value=None):
 def create(ctx,
            ddb_table_name,
            datomic_version,
+           datomic_ext_classpath_script,
            desired_capacity,
            cf_template_path):
     """Create a new CloudFormation stack for Datomic tranactor(s).
@@ -236,6 +242,8 @@ def create(ctx,
         _parameter('DatomicVersion', datomic_version),
         _parameter('AutoScalingDesiredCapacity', desired_capacity),
     ]
+    if datomic_ext_classpath_script:
+        params += [_parameter('DatomicExtClasspathScript', datomic_ext_classpath_script)]
     params.extend(_parameter(k, v)
                   for (k, v) in  ctx.params.items())
     kw = dict(StackName=ctx.cf_stack_name,
@@ -251,13 +259,19 @@ def create(ctx,
         default=None,
         type=str,
         help='If not specified, use existing version')
-@template_path_option(default=None)
+@option('--datomic-ext-classpath-script',
+        default=None,
+        type=str,
+        help=('Optional arguments to custom script to download dependencies '
+              'and build the classpath string for DATOMIC_EXT_CLASSPATH, if provided.'))
 @desired_capacity_option()
+@template_path_option(default=None)
 @pass_command_context
 @command_result_reporter
 def update(ctx,
            ddb_table_name,
            datomic_version,
+           datomic_ext_classpath_script,
            desired_capacity,
            cf_template_path):
     """Update the CloudFormation configuration of the Datomic transactor(s).
@@ -268,6 +282,8 @@ def update(ctx,
         _parameter('DatomicVersion', datomic_version),
         _parameter('AutoScalingDesiredCapacity', desired_capacity),
     ]
+    if datomic_ext_classpath_script:
+        params += [_parameter('DatomicExtClasspathScript', datomic_ext_classpath_script)]
     params.extend(_parameter(k, v)
                   for (k, v) in  ctx.params.items())
     kw = dict(StackName=ctx.cf_stack_name,

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -200,7 +200,7 @@
                   "Fn::Join": [
                     "=",
                     [
-                      "export DATOMIC_TRANACTOR_DEPS_SCRIPT",
+                      "export DATOMIC_TRANSACTOR_DEPS_SCRIPT",
 		      {
                         "Ref": "DatomicTransactorDepsScript"
                       }

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -196,10 +196,6 @@
 		    ]
 		  ]
 		},
-                "[ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ] && wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT",
-                "[ -f /tmp/build_datomic_ext_classpath.sh ] && chmod u+x /tmp/build_datomic_ext_classpath.sh",
-                "[ -f /tmp/build_datomic_ext_classpath.sh ] && export DATOMIC_EXT_CLASSPATH=\"$(/tmp/build_datomic_ext_classpath.sh)\"",
-                "echo \"DATOMIC_EXT_CLASSPATH=\"${DATOMIC_EXT_CLASSPATH}\"\"",
                 "cd /datomic",
                 "cat <<EOF >aws.properties",
                 "host=`curl http://169.254.169.254/latest/meta-data/local-ipv4`",
@@ -289,7 +285,7 @@
                 },
                 "encrypt-channel=false",
                 "EOF",
-                "AWS_ACCESS_KEY_ID=\"${DATOMIC_READ_DEPLOY_ACCESS_KEY_ID}\" AWS_SECRET_ACCESS_KEY=\"${DATOMIC_READ_DEPLOY_AWS_SECRET_KEY}\" aws s3 cp \"s3://${DATOMIC_DEPLOY_BUCKET}/${DATOMIC_VERSION}/startup.sh\" startup.sh",
+                "wget -O startup.sh https://raw.githubusercontent.com/WormBase/wormbase-architecture/develop/transactor/startup.sh",
                 "chmod 744 aws.properties",
                 "chmod 500 startup.sh",
                 {

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -196,6 +196,17 @@
 		    ]
 		  ]
 		},
+                {
+                  "Fn::Join": [
+                    "=",
+                    [
+                      "export DATOMIC_TRANACTOR_DEPS_SCRIPT",
+		      {
+                        "Ref": "DatomicTransactorDepsScript"
+                      }
+		    ]
+                  ]
+		},
                 "cd /datomic",
                 "cat <<EOF >aws.properties",
                 "host=`curl http://169.254.169.254/latest/meta-data/local-ipv4`",
@@ -492,6 +503,10 @@
       "Type": "String",
       "NoEcho": "true",
       "Description": "Wormbase's datomic-pro license key"
+    },
+    "DatomicTransactorDepsScript": {
+      "Type": "String",
+      "Description": "URL to script to install deps for the datomic transactor"
     },
     "DatomicExtClasspathScript": {
       "Default": "",

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -285,7 +285,7 @@
                 },
                 "encrypt-channel=false",
                 "EOF",
-                "wget -O startup.sh https://raw.githubusercontent.com/WormBase/wormbase-architecture/develop/transactor/startup.sh",
+                "wget -O startup.sh https://raw.githubusercontent.com/WormBase/wormbase-architecture/feature/set-datomic-ext-classpath-for-transactor/transactor/startup.sh",
                 "chmod 744 aws.properties",
                 "chmod 500 startup.sh",
                 {

--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -185,6 +185,21 @@
                     ]
                   ]
                 },
+		{
+                  "Fn::Join": [
+                    "=",
+                    [
+                      "export DATOMIC_EXT_CLASSPATH_SCRIPT",
+                      {
+                        "Ref": "DatomicExtClasspathScript"
+                      }
+		    ]
+		  ]
+		},
+                "[ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ] && wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT",
+                "[ -f /tmp/build_datomic_ext_classpath.sh ] && chmod u+x /tmp/build_datomic_ext_classpath.sh",
+                "[ -f /tmp/build_datomic_ext_classpath.sh ] && export DATOMIC_EXT_CLASSPATH=\"$(/tmp/build_datomic_ext_classpath.sh)\"",
+                "echo \"DATOMIC_EXT_CLASSPATH=\"${DATOMIC_EXT_CLASSPATH}\"\"",
                 "cd /datomic",
                 "cat <<EOF >aws.properties",
                 "host=`curl http://169.254.169.254/latest/meta-data/local-ipv4`",
@@ -481,6 +496,11 @@
       "Type": "String",
       "NoEcho": "true",
       "Description": "Wormbase's datomic-pro license key"
+    },
+    "DatomicExtClasspathScript": {
+      "Default": "",
+      "Description": "The script for building the DATOMIC_EXT_CLASSPATH.",
+      "Type": "String"
     },
     "DDBTableName": {
       "Type": "String",

--- a/transactor/startup.sh
+++ b/transactor/startup.sh
@@ -8,13 +8,19 @@ export DATOMIC_DEPLOY_DIR=${DATOMIC_HOME}/${DATOMIC_NAME}
 
 DEPS_INSTALLER=/tmp/install_tx_deps.sh
 
-[ ! -z $DATOMIC_TRANSACTOR_DEPS_SCRIPT ] && wget -O $DEPS_INSTALLER $DATOMIC_TRANSACTOR_DEPS_SCRIPT
-[ -f $DEPS_INSTALLER ] && chmod +x $DEPS_INSTALLER && $DEPS_INSTALLER
-
-[ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ] && wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT
-[ -f /tmp/build_datomic_ext_classpath.sh ] && chmod +x /tmp/build_datomic_ext_classpath.sh
-[ -f /tmp/build_datomic_ext_classpath.sh ] && \
-    export DATOMIC_EXT_CLASSPATH="$(su - datomic -c 'CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh')"
+if [ ! -z $DATOMIC_TRANSACTOR_DEPS_SCRIPT ]; then
+    wget -O $DEPS_INSTALLER $DATOMIC_TRANSACTOR_DEPS_SCRIPT
+    chmod +x $DEPS_INSTALLER
+    /bin/bash $DEPS_INSTALLER
+    if [ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ]; then
+	wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT
+	chmod +x /tmp/build_datomic_ext_classpath.sh
+	export DATOMIC_EXT_CLASSPATH="$(su - datomic -c 'CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh')"
+    fi
+else
+    echo "DATOMIC_TRANSACTOR_DEPS_SCRIPT was not set"
+    echo "Not setting DATOMIC_EXT_CLASSPATH"
+fi
 
 printenv > /dev/console
 

--- a/transactor/startup.sh
+++ b/transactor/startup.sh
@@ -6,13 +6,15 @@ export DATOMIC_NAME=datomic-pro-${DATOMIC_VERSION}
 export DATOMIC_ZIP=${DATOMIC_NAME}.zip
 export DATOMIC_DEPLOY_DIR=${DATOMIC_HOME}/${DATOMIC_NAME}
 
+DEPS_INSTALLER=/tmp/install_tx_deps.sh
+
+[ ! -z $DATOMIC_TRANSACTOR_DEPS_SCRIPT ] && wget -O $DEPS_INSTALLER $DATOMIC_TRANSACTOR_DEPS_SCRIPT
+[ -f $DEPS_INSTALLER ] && chmod +x $DEPS_INSTALLER && $DEPS_INSTALLER
+
 [ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ] && wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT
 [ -f /tmp/build_datomic_ext_classpath.sh ] && chmod +x /tmp/build_datomic_ext_classpath.sh
 [ -f /tmp/build_datomic_ext_classpath.sh ] && \
     export DATOMIC_EXT_CLASSPATH="$(su - datomic -c 'CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh')"
-
-[ ! -z $DATOMIC_TRANSACTOR_DEPS_SCRIPT ] && wget -O /tmp/install_tx_deps.sh $DATOMIC_TRANSACTOR_DEPS_SCRIPT
-[ -f /tmp/intall_tx_deps.sh ] && chmod +x /tmp/intall_tx_deps.sh && /tmp/install_tx_deps.sh    
 
 printenv > /dev/console
 

--- a/transactor/startup.sh
+++ b/transactor/startup.sh
@@ -11,6 +11,9 @@ export DATOMIC_DEPLOY_DIR=${DATOMIC_HOME}/${DATOMIC_NAME}
 [ -f /tmp/build_datomic_ext_classpath.sh ] && \
     export DATOMIC_EXT_CLASSPATH="$(su - datomic -c 'CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh')"
 
+[ ! -z $DATOMIC_TRANSACTOR_DEPS_SCRIPT ] && wget -O /tmp/install_tx_deps.sh $DATOMIC_TRANSACTOR_DEPS_SCRIPT
+[ -f /tmp/intall_tx_deps.sh ] && chmod +x /tmp/intall_tx_deps.sh && /tmp/install_tx_deps.sh    
+
 printenv > /dev/console
 
 if [ -f "${DATOMIC_HOME}/bin/aws" ]
@@ -26,12 +29,14 @@ chown -R datomic ${DATOMIC_DEPLOY_DIR}
 cd ${DATOMIC_DEPLOY_DIR}
 . /etc/init.d/functions
 
-echo "Running transactor with params:"
+ echo "Running transactor with params:"
 echo "${DATOMIC_DEPLOY_DIR}/bin/transactor -Xms$XMX -Xmx$XMX $JAVA_OPTS ${DATOMIC_HOME}/aws.properties"
 aws s3 cp ${DATOMIC_HOME}/aws.properties s3://transactor-logs/aws.properties.wb-names
 
+echo "export DATOMIC_EXT_CLASSPATH=$DATOMIC_EXT_CLASSPATH" >> ~datomic/.bash_profile
+chown datomic ~datomic/.bash_profile
+
 daemon \
-    --env="DATOMIC_EXT_CLASPSATH=$DATOMIC_EXT_CLASPSATH" \
     --user=datomic ${DATOMIC_DEPLOY_DIR}/bin/transactor \
     -Xms$XMX \
     -Xmx$XMX \

--- a/transactor/startup.sh
+++ b/transactor/startup.sh
@@ -7,9 +7,9 @@ export DATOMIC_ZIP=${DATOMIC_NAME}.zip
 export DATOMIC_DEPLOY_DIR=${DATOMIC_HOME}/${DATOMIC_NAME}
 
 [ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ] && wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT
-[ -f /tmp/build_datomic_ext_classpath.sh ] && chmod u+x /tmp/build_datomic_ext_classpath.sh
+[ -f /tmp/build_datomic_ext_classpath.sh ] && chmod +x /tmp/build_datomic_ext_classpath.sh
 [ -f /tmp/build_datomic_ext_classpath.sh ] && \
-    export DATOMIC_EXT_CLASSPATH="$(su - datomic -c CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh)"
+    export DATOMIC_EXT_CLASSPATH="$(su - datomic -c 'CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh')"
 
 printenv > /dev/console
 
@@ -30,7 +30,9 @@ echo "Running transactor with params:"
 echo "${DATOMIC_DEPLOY_DIR}/bin/transactor -Xms$XMX -Xmx$XMX $JAVA_OPTS ${DATOMIC_HOME}/aws.properties"
 aws s3 cp ${DATOMIC_HOME}/aws.properties s3://transactor-logs/aws.properties.wb-names
 
-daemon --user=datomic ${DATOMIC_DEPLOY_DIR}/bin/transactor \
+daemon \
+    --env="DATOMIC_EXT_CLASPSATH=$DATOMIC_EXT_CLASPSATH" \
+    --user=datomic ${DATOMIC_DEPLOY_DIR}/bin/transactor \
     -Xms$XMX \
     -Xmx$XMX \
     $JAVA_OPTS \

--- a/transactor/startup.sh
+++ b/transactor/startup.sh
@@ -6,6 +6,11 @@ export DATOMIC_NAME=datomic-pro-${DATOMIC_VERSION}
 export DATOMIC_ZIP=${DATOMIC_NAME}.zip
 export DATOMIC_DEPLOY_DIR=${DATOMIC_HOME}/${DATOMIC_NAME}
 
+[ ! -z $DATOMIC_EXT_CLASSPATH_SCRIPT ] && wget -O /tmp/build_datomic_ext_classpath.sh $DATOMIC_EXT_CLASSPATH_SCRIPT
+[ -f /tmp/build_datomic_ext_classpath.sh ] && chmod u+x /tmp/build_datomic_ext_classpath.sh
+[ -f /tmp/build_datomic_ext_classpath.sh ] && \
+    export DATOMIC_EXT_CLASSPATH="$(su - datomic -c CONSOLE_DEVICE=/dev/stderr /tmp/build_datomic_ext_classpath.sh)"
+
 printenv > /dev/console
 
 if [ -f "${DATOMIC_HOME}/bin/aws" ]


### PR DESCRIPTION
This change is a requirement for the `names` project, which uses the [classpath functions][1] feature of datomic.

These changes will set DATOMIC_EXT_CLASSPATH before running the transactor.
This works by specifying a script (as a URL) to a _optional_ parameter to the `manage` script, which in turn is passed to the CloudFormation template which will:
 * fetch the script
 * make it executable
 * run it (without arguments) 
 * assign the contents of the script output to the `DATOMIC_EXT_CLASSPATH` environment variable

, before continuing to run startup.sh as before.

[1]: https://docs.datomic.com/on-prem/database-functions.html#classpath-functions