### PR TITLE
Add parameter to enable rolling update.

### DIFF
--- a/transactor/config/wb-cf-ensured.json
+++ b/transactor/config/wb-cf-ensured.json
@@ -118,8 +118,9 @@
             }
           ]
         },
-        "UserData": {
+	"UserData": {
           "Fn::Base64": {
+            "Ref": "Toggle",
             "Fn::Join": [
               "\n",
               [
@@ -465,6 +466,12 @@
     }
   },
   "Parameters": {
+    "Toggle": {
+        "Description": "Used to force a rolling update. Set to the inverse of current value (true/false)",
+        "Type": "String",
+        "AllowedValues": ["false","true"],
+        "Default": "true"
+    },
     "InstanceType": {
       "Description": "Type of EC2 instance to launch",
       "Type": "String"


### PR DESCRIPTION
This is to enable rolling updates without any changes as described [here][1].
Rolling updates are used in a typical datomic setup to cause the transactors to cycle, without the peer application being affected by downtime.

As such, this only affects the Names Service, as there is only one transactor instance in play for the main release database.

[1]: https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-rolling-updates-launch/
